### PR TITLE
Solidity Indexing Argument Fix

### DIFF
--- a/README.md
+++ b/README.md
@@ -240,8 +240,9 @@ contract Array {
         uint length = arr.length;
         // Delete does not change the array length.
         // It resets the value at index to it's default value,
-        // in this case 0
-        delete arr[index];
+        // in this case it resets the value at index 1 in arr2 to 0
+        uint index = 1;
+        delete arr2[index];
         // create array in memory, only fixed size can be created
         uint[] memory a = new uint[](5);
         // create string in memory


### PR DESCRIPTION
I noticed in the Solidity lesson that we are referencing a value in the `arr` array with an undeclared `index` variable. I'm proposing a small cleanup here to make it more clear that we are resetting a value in an existing array (`arr2`) that has values which can be reset to 0. Open to feedback or suggestions as well.